### PR TITLE
Fix getValue for boolean types

### DIFF
--- a/lib/byte_buffer.js
+++ b/lib/byte_buffer.js
@@ -402,6 +402,7 @@ class ByteBuffer {
     return { value, len };
   }
 
+  // TODO this is broken for arrays of objects when the array has null references and makes the tag = 0
   getArrayRegion(index) {
     let moveOffset = false;
     if (typeof index !== 'number') {

--- a/lib/byte_buffer.js
+++ b/lib/byte_buffer.js
@@ -329,7 +329,7 @@ class ByteBuffer {
         break;
       case 90: // BOOLEAN
         len = 1;
-        value = this._bytes.getByte(index + 1) === 1;
+        value = this.getByte(index + 1) === 1;
         break;
       default:
         break;
@@ -394,7 +394,7 @@ class ByteBuffer {
         break;
       case 90: // BOOLEAN
         len = 1;
-        value = this._bytes.getByte(index) === 1;
+        value = this.getByte(index) === 1;
         break;
       default:
         break;

--- a/lib/command/const/tag.js
+++ b/lib/command/const/tag.js
@@ -1,5 +1,6 @@
 'use strict';
 
+exports.NULL = 0;
 exports.ARRAY = 91;
 exports.BYTE = 66;
 exports.CHAR = 67;

--- a/lib/command/virtual_machine/all_threads.js
+++ b/lib/command/virtual_machine/all_threads.js
@@ -23,7 +23,7 @@ class AllThreads extends Base {
     for (let i = 0; i < count; i++) {
       threads.push(obj.data.getThreadID());
     }
-    return threads;
+    return { threads };
   }
 }
 

--- a/lib/event_request_manager.js
+++ b/lib/event_request_manager.js
@@ -5,7 +5,7 @@ const ClassUnloadRequest = require('./event/class_unload_request');
 const ClassPrepareRequest = require('./event/class_prepare_request');
 const MethodEntryRequest = require('./event/method_entry_request');
 const StepRequest = require('./event/step_request');
-const { ClearAllBreakpoints } = require('./command').EventRequest;
+const { ClearAllBreakpoints, Clear } = require('./command').EventRequest;
 
 
 class EventRequestManager {
@@ -35,6 +35,10 @@ class EventRequestManager {
 
   async deleteAllBreakpoints() {
     await this.vm.send(new ClearAllBreakpoints());
+  }
+
+  async clearCommand(eventKind, eventRequestID) {
+    await this.vm.send(new Clear({ eventKind: eventKind, id: eventRequestID }));
   }
 }
 

--- a/lib/value/array_reference.js
+++ b/lib/value/array_reference.js
@@ -90,6 +90,8 @@ class ArrayReference extends ObjectReference {
           return new ShortValue(this.vm, v);
         case Tag.BOOLEAN:
           return new BooleanValue(this.vm, v);
+          
+        case Tag.NULL:
         case Tag.VOID:
           return new VoidValue(this.vm);
         default:

--- a/lib/virtual_machine.js
+++ b/lib/virtual_machine.js
@@ -461,7 +461,7 @@ class VirtualMachine extends Base {
     // TODO: local cache
     const { groups } = await this.send(new TopLevelThreadGroups());
 
-    return groups.map(id => { return ThreadGroupReference(this, id); });
+    return groups.map(id => { return new ThreadGroupReference(this, id); });
   }
 
   async getClasspath() {


### PR DESCRIPTION
I ran into an issue when trying to request the value of a stackframe variable when it was the boolean type.

```javascript
(node:11980) UnhandledPromiseRejectionWarning: TypeError: this._bytes.getByte is not a function
    at ByteBuffer.getValue (D:\Studium\Masterarbeit\projects\jdwp-react\backend\node_modules\jdwp\lib\byte_buffer.js:332:29)
    at GetValues.decode (D:\Studium\Masterarbeit\projects\jdwp-react\backend\node_modules\jdwp\lib\command\stack_frame\get_values.js:38:24)
    at JDWPConnection._handlePacket (D:\Studium\Masterarbeit\projects\jdwp-react\backend\node_modules\jdwp\lib\connection.js:100:40)
```

Taking a look at the code it seemed it was trying to call the .getByte() function of Buffer which does not exist. It seems it was supposed to call the this.getByte() function instead.

```
      case 90: // BOOLEAN
        len = 1;
        value = this._bytes.getByte(index + 1) === 1;
        break;
```

PS: Good job on this library overall!
